### PR TITLE
🐛 Exception when all tasks are done

### DIFF
--- a/pls_cli/please.py
+++ b/pls_cli/please.py
@@ -46,7 +46,7 @@ author_style = os.getenv('PLS_AUTHOR_STYLE', '#a0a0a0')
 
 background_bar_style = os.getenv('PLS_BACKGROUND_BAR_STYLE', 'bar.back')
 complete_bar_style = os.getenv('PLS_COMPLETE_BAR_STYLE', 'bar.complete')
-finished_bar_style = os.getenv('PLS_FINISHED_BAR_STYLE', 'bar.done')
+finished_bar_style = os.getenv('PLS_FINISHED_BAR_STYLE', 'bar.finished')
 
 
 def get_terminal_full_width() -> int:

--- a/tests/test_pls_cli.py
+++ b/tests/test_pls_cli.py
@@ -2,9 +2,10 @@ from unittest.mock import patch
 
 import pkg_resources
 from freezegun import freeze_time
+from typer.testing import CliRunner
+
 from pls_cli import __version__
 from pls_cli.please import app
-from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -87,14 +88,14 @@ def test_config_ok_no_tasks_pending(
     assert "Hello Test name! It's 14 Jan | 03:21 AM" in result.stdout
     assert 'Looking good, no pending tasks ✨ 🍰 ✨' in result.stdout
 
+
 @patch('pls_cli.utils.settings.Settings.exists_settings', return_value=True)
 @patch(
     'pls_cli.utils.settings.Settings.get_tasks',
     return_value=[{'name': 'Task 1', 'done': True}],
 )
 def test_config_ok_no_tasks_pending_with_progress(
-    mock_get_tasks,
-     mock_exists_settings
+    mock_get_tasks, mock_exists_settings
 ):
     result = runner.invoke(app)
     assert result.exit_code == 0

--- a/tests/test_pls_cli.py
+++ b/tests/test_pls_cli.py
@@ -2,10 +2,9 @@ from unittest.mock import patch
 
 import pkg_resources
 from freezegun import freeze_time
-from typer.testing import CliRunner
-
 from pls_cli import __version__
 from pls_cli.please import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -87,6 +86,18 @@ def test_config_ok_no_tasks_pending(
     assert result.exit_code == 0
     assert "Hello Test name! It's 14 Jan | 03:21 AM" in result.stdout
     assert 'Looking good, no pending tasks ✨ 🍰 ✨' in result.stdout
+
+@patch('pls_cli.utils.settings.Settings.exists_settings', return_value=True)
+@patch(
+    'pls_cli.utils.settings.Settings.get_tasks',
+    return_value=[{'name': 'Task 1', 'done': True}],
+)
+def test_config_ok_no_tasks_pending_with_progress(
+    mock_get_tasks,
+     mock_exists_settings
+):
+    result = runner.invoke(app)
+    assert result.exit_code == 0
 
 
 @patch(


### PR DESCRIPTION
Hi Felipe,

**Issue:**
A fresh install with `show_task_progress=true` will throw a `MissingStyle: Failed to get style 'bar.done';` Exception when all tasks are done. 

**Fix:**
This is apparently a documentation issue in rich. The documentation says the default should be `bar.done` but actually it is `bar.finished`. I changed the corresponding line in pls-cli.

**Test:**
I added a test that would catch this error (i.e. that should create a finished progress bar). Since this was not caught by `test_config_ok_no_tasks_pending` there might be some problems with the patching?

Also: thanks for the tool, looks great so far! I will test it the next days, maybe you will hear from me again ;) 