### PR TITLE
Feature: Editing an existing task

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,6 +25,7 @@ pls --help
 │ del          Delete a Task                                                   │
 │ delete       Delete a Task                                    (deprecated)   │
 │ done         Mark a task as done ✓                                           │
+│ edit         Edit a Task                                                     │
 │ move         Change task order 🔀                                            │
 │ showtasks    Show all Tasks 📖                                (deprecated)   │
 │ tasks        Show all Tasks 📖                                               │

--- a/pls_cli/please.py
+++ b/pls_cli/please.py
@@ -565,3 +565,47 @@ def config():
     """Launch config directory :open_file_folder:"""
     center_print(Rule('・Opening config directory・', style='#d77dd8'))
     typer.launch(Settings().get_full_settings_path(), locate=True)
+
+
+@app.command()
+def edit(task_id: int, task: str):
+    """[bold yellow]Edit[/bold yellow] a task by id ✏️ [light_slate_grey italic] (Add task name inside quotes)[/]"""
+    settings = Settings().get_settings()
+    tasks = settings['tasks']
+
+    # check if task list is empty
+    if not tasks:
+        center_print(
+            f'[{warning_text_style}]Currently, you have no tasks to edit[/] 📝'
+        )
+        print_tasks_progress()
+        raise typer.Exit()
+
+    print_tasks()
+
+    # check if task exists
+    if task_id and task_id <= len(tasks):
+        old_task = tasks[task_id - 1]['name']
+        tasks[task_id - 1]['name'] = task
+    else:
+        center_print(
+            f'\nTask #{task_id} was not found, pls choose an existing ID\n',
+            style=error_text_style,
+        )
+        raise typer.Exit()
+
+    # confirm edit task
+    center_print(
+        f'\nOld Task: {old_task}\nEdited Task: {task}\n',
+        style=insert_or_delete_text_style,
+    )
+    if not typer.confirm(
+        f'Are you sure you want to edit Task #{task_id}?', show_default=True
+    ):
+        typer.clear()
+        print_tasks()
+        raise typer.Exit()
+
+    Settings().write_settings(settings)
+    typer.clear()
+    print_tasks()


### PR DESCRIPTION
First of all, I would like to thank you for this great tool.

I notice that it is not possible to edit an existing task, this PR adds this feature. Currently, this feature only supports inline editing.

```bash
$ pls

ID     TASK     STATUS                                                            
━━━━━━━━━━━━━━━━━━
1    task 1            ○ 
2    task 2            ○ 

$ pls edit 2 'edited'

Are you sure you want to edit Task #2? [y/N]: y

ID     TASK     STATUS                                                            
━━━━━━━━━━━━━━━━━━
1    task 1            ○ 
2    edited            ○ 

```

