### PR TITLE
Add config file path.

### DIFF
--- a/pls_cli/please.py
+++ b/pls_cli/please.py
@@ -561,10 +561,19 @@ def docs():
 
 
 @app.command(rich_help_panel='Utils and Configs')
-def config():
+def config(
+    path: bool = typer.Option(False, "--path", "-p", help="Show config file path")
+):
     """Launch config directory :open_file_folder:"""
-    center_print(Rule('・Opening config directory・', style='#d77dd8'))
-    typer.launch(Settings().get_full_settings_path(), locate=True)
+    config_path = Settings().get_config_path()
+    full_settings_path = Settings().get_full_settings_path()
+
+    if not path:
+        center_print(Rule(f'・[white]Opening config directory ({config_path})[/]・',
+                           style='#d77dd8'))
+        typer.launch(full_settings_path, locate=True)
+    else:
+        console.print(f":open_file_folder: Settings file path: {full_settings_path}")
 
 
 @app.command()


### PR DESCRIPTION
When `pls config` is called, it performs the same action as before but if `-p` or `--path` is added, it displays the file path instead of open the directory in explorer.